### PR TITLE
fix(pkg): add types condition to exports and files allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aivangogh/ph-address",
-  "version": "2025.4.3",
+  "version": "2025.4.4",
   "description": "A collection of philippine geographic data based on PSGC",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -18,11 +18,7 @@
     },
     "./package.json": "./package.json"
   },
-  "files": [
-    "dist",
-    "LICENCE",
-    "README.md"
-  ],
+  "files": ["dist", "LICENCE", "README.md"],
   "author": {
     "name": "Ivan Gemota",
     "email": "aivangogh.dev@gmail.com",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,23 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.js"
+    ".": {
+      "import": {
+        "types": "./dist/index.d.mts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      }
+    },
+    "./package.json": "./package.json"
   },
+  "files": [
+    "dist",
+    "LICENCE",
+    "README.md"
+  ],
   "author": {
     "name": "Ivan Gemota",
     "email": "aivangogh.dev@gmail.com",


### PR DESCRIPTION
## Summary

- Adds per-condition `types` entries to the `exports` map so TypeScript consumers using `moduleResolution: Node16 | NodeNext | Bundler` can resolve types. Closes #13.
- Exports `./package.json` for tools that introspect it.
- Adds a `files` allowlist so npm publishes only `dist/`, `LICENCE`, and `README.md` — keeps `src/`, `scripts/`, `tests/`, lockfiles, and `.changeset/` out of the tarball.

## Why

Currently `exports` only declares `import`/`require`. Under modern TS module resolution (`Node16`/`NodeNext`/`Bundler`), TypeScript reads from the `exports` map and ignores the top-level `types` fallback — so consumers get *"Could not find a declaration file for module '@aivangogh/ph-address'"* even though `dist/index.d.ts` ships.

`tsup` already emits both `index.d.ts` and `index.d.mts`, so this PR wires each format to its matching declaration file.

## Verification

`@arethetypeswrong/cli --pack .` — all green:

| Resolution        | Result    |
|-------------------|-----------|
| node10            | OK        |
| node16 (from CJS) | OK (CJS)  |
| node16 (from ESM) | OK (ESM)  |
| bundler           | OK        |

Existing test suite still passes: **39 pass / 0 fail** (`bun test`).

## Test plan

- [x] `bun run build` succeeds, both `.d.ts` and `.d.mts` emitted.
- [x] `bunx @arethetypeswrong/cli --pack .` reports no problems across all resolution modes.
- [x] `bun test` — all 39 tests pass.
- [ ] (Maintainer) Consider a patch bump (e.g. `2025.4.4`) and a changeset entry noting the packaging fix.

## Notes

Suggested labels: `bug`, `types`, `packaging`. (Couldn't apply from a fork.)